### PR TITLE
header, main 미디어쿼리 적용 작업

### DIFF
--- a/css/media_query.css
+++ b/css/media_query.css
@@ -2,14 +2,49 @@
 
 @media screen and (max-width: 1024px) {
   /* header: 장서령 */
-
+  .header-cont {
+    padding: 20px 0px;
+  }
 
   /* main: 장서령 */
+  .sponsor {
+    display: none;
+  }
 
+  .news {
+    width: 100%;
+    padding: 20px;
+  }
 
+  .news h2 {
+    font-size: 20px;
+  }
+
+  .news-category {
+    justify-content: center;
+  }
+
+  .news-card {
+    margin-bottom: 20px;
+  }
+
+  .card-img-frame {
+    min-width: 144px;
+    margin-right: 10px;
+  }
+
+  .card-cont {
+    width: calc(100% - 150px);
+  }
+
+  .card-tit {
+    font-size: 20px;
+  }
+
+  .button-more {
+    margin: 0 auto 10px;
+  }
   /* modal: 심채영 */
 
-
   /* footer: 윤수영 */
-  
 }

--- a/css/media_query.css
+++ b/css/media_query.css
@@ -17,7 +17,17 @@
   }
 
   .news h2 {
-    font-size: 20px;
+    font-size: 25px;
+  }
+
+  .search {
+    width: 200px;
+    height: 3rem;
+  }
+
+  .search-button {
+    top: 0;
+    height: 3px;
   }
 
   .news-category {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./css/reset.css" />
     <link rel="stylesheet" href="./css/font.css" />
     <link rel="stylesheet" href="./css/style.css" />
+    <link rel="stylesheet" href="./css/media_query.css">
   </head>
 
   <body>


### PR DESCRIPTION
### header
- 모바일 시 로고와 언어 버튼 크기를 고려해 padding만 조절했습니다.

### main
- sponsor는 display none값을 주어 화면의 크기가 줄어들면 아예 보이지 않도록 했습니다.
- news category는 가운데 정렬로 맞추고, 폰트 크기는 더 작아지면 가독성에 불편함을 줄 수 있을 것 같아 변경하지 않았습니다.
- news card에서는 image의 width를 조절해 기사의 제목, 내용이 좀 더 보일 수 있도록 했습니다. 